### PR TITLE
Cải thiện chức năng báo cáo tài liệu trong DocumentDetailScreen

### DIFF
--- a/app/lib/features/home/widgets/document_detail.dart
+++ b/app/lib/features/home/widgets/document_detail.dart
@@ -256,6 +256,8 @@ class _DocumentDetailScreenState extends State<DocumentDetailScreen> {
         body: const Center(child: Text('Không tìm thấy tài liệu')),
       );
     }
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    final userId = authProvider.user?.id;
     return Scaffold(
       appBar: AppBar(
         leading: Padding(
@@ -334,13 +336,17 @@ class _DocumentDetailScreenState extends State<DocumentDetailScreen> {
                               maxLines: 2,
                             ),
                           ),
-                          IconButton(
-                            icon: const Icon(Icons.report, color: Colors.red),
-                            tooltip: 'Báo cáo',
-                            onPressed: () {
-                              _showReportDialog();
-                            },
-                          ),
+                          if ((document!.uploaderId is String &&
+                                  document!.uploaderId != userId) ||
+                              (document!.uploaderId is DocumentUploader &&
+                                  document!.uploaderId.id != userId))
+                            IconButton(
+                              icon: const Icon(Icons.report, color: Colors.red),
+                              tooltip: 'Báo cáo',
+                              onPressed: () {
+                                _showReportDialog();
+                              },
+                            ),
                         ],
                       ),
 


### PR DESCRIPTION
- Thêm chức năng truy xuất ID người dùng từ AuthProvider để xác định danh tính của người tải lên.
- Cập nhật logic hiển thị nút báo cáo để chỉ hiển thị cho các tài liệu do người dùng khác ngoài người dùng hiện tại tải lên, cải thiện trải nghiệm của người dùng và ngăn chặn việc tự báo cáo.